### PR TITLE
Use `printf` instead of `echo` for consistent output

### DIFF
--- a/boltflow.sh
+++ b/boltflow.sh
@@ -63,7 +63,7 @@ fi
 git config core.fileMode false
 
 if ! (git pull) then
-    echo "\n\nGit pull was not successful. Fix what went wrong, and run this script again.\n\n"
+    printf "\n\nGit pull was not successful. Fix what went wrong, and run this script again.\n\n"
     exit 1
 fi
 


### PR DESCRIPTION
`echo` on my `bash` command line prints a literal `\n` in the output.

Source: https://stackoverflow.com/questions/8467424/echo-newline-in-bash-prints-literal-n