### PR TITLE
Make git optional and added red color for Git warnings

### DIFF
--- a/boltflow.sh
+++ b/boltflow.sh
@@ -60,11 +60,15 @@ if [[ ! -f "$WD/composer.json" ]] ; then
     mv $WD/composer.json.dist $WD/composer.json
 fi
 
-git config core.fileMode false
+if [ -d "$WD/.git" ]; then
+    git config core.fileMode false
 
-if ! (git pull) then
-    printf "\n\nGit pull was not successful. Fix what went wrong, and run this script again.\n\n"
-    exit 1
+    if ! (git pull) then
+        printf "\n\n\e[31mGit pull was not successful. Fix what went wrong, and run this script again.\n\n"
+        exit 1
+    fi
+else
+    printf "\e[31mNo git repository found.\n"
 fi
 
 if [[ ! -f "$WD/composer.json" ]] ; then

--- a/boltflow.sh
+++ b/boltflow.sh
@@ -63,7 +63,7 @@ fi
 git config core.fileMode false
 
 if ! (git pull) then
-    echo "\n\nGit pull was not successful. Fix what went wrong, and run this script again.\n\n"
+    printf "\n\nGit pull was not successful. Fix what went wrong, and run this script again.\n\n"
     exit 1
 fi
 


### PR DESCRIPTION
What do you think about this?

Shows a warning in red if there is no Git repository. This allows the use of Boltflow quickly without any existing Git repo. This basically means the `chmod`ding of folders/files, fetching the composer packages and clearing the cache.